### PR TITLE
Missing 'end' in StatTracker

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -20,7 +20,7 @@ class StatTracker
   include Creators
   include Helper
 
-
+  
   def initialize(locations)
     @game_data = create_games(locations[:games])
     @game_teams_data = create_game_teams(locations[:game_teams])
@@ -30,3 +30,4 @@ class StatTracker
   def self.from_csv(locations)
     StatTracker.new(locations)
   end
+end


### PR DESCRIPTION
StatTracker class somehow had an 'end' missing.  Being so small now, it was very easy to find though.